### PR TITLE
media type check

### DIFF
--- a/src/js-store/src/server.js
+++ b/src/js-store/src/server.js
@@ -236,7 +236,7 @@ Server.start = function() {
 
                 if(toLoad === 'stdin') {
                     var mediaType = options['media-type'];
-                    if(mediaType == null) {
+                    if(mediaType != null) {
                         var data = "";
                         process.stdin.resume();
                         process.stdin.setEncoding('utf8');
@@ -262,7 +262,7 @@ Server.start = function() {
                 } else {
                     if(toLoad.indexOf("file:/")==0) {
                         var mediaType = options['media-type'];
-                        if(mediaType == null) {
+                        if(mediaType != null) {
                             if(dstGraph != null) {
                                 Server.store.load(mediaType, toLoad, dstGraph, function(){
                                     process.exit(0);


### PR DESCRIPTION
Hi Antonio,

Thank you for your great work!

When I tried to load a local RDF file, I got a following error message

```
% ./bin/rdfstorejs load file:///opt/rdf/sample.ttl http://test.db/sample --media-type 'text/turtle' --store-name sample --store-engine mongodb 
Error: Media type used to encode incoming data must be specified using the --media-type flag when loading data from disk or stdin
```

and found this is caused by the inverse condition.

Cheers,
Toshiaki Katayama
