### PR TITLE
When casting string values as dateTime, parse tolerantly.

### DIFF
--- a/src/js-query-engine/src/query_filters.js
+++ b/src/js-query-engine/src/query_filters.js
@@ -1631,7 +1631,7 @@ QueryFilters.runIriRefOrFunction = function(iriref, args, bindings,queryEngine, 
                 return from;
             } else if(from.type == "http://www.w3.org/2001/XMLSchema#string" || from.type == null) {
                 try {
-                    from.value = Utils.iso8601(Utils.parseStrictISO8601(from.value));
+                    from.value = Utils.iso8601(Utils.parseISO8601(from.value));
                     from.type = fun;
                     return from;
                 } catch(e) {

--- a/src/js-query-engine/test/test_cases.js
+++ b/src/js-query-engine/test/test_cases.js
@@ -4285,6 +4285,32 @@ exports.testOpenDate4 = function(test) {
     });
 }
 
+exports.testDateCast01 = function(test) {
+    new Lexicon.Lexicon(function(lexicon){
+        new QuadBackend.QuadBackend({treeOrder: 2}, function(backend){
+            var engine = new QueryEngine.QueryEngine({backend: backend,
+                                                      lexicon: lexicon});      
+            var query = 'PREFIX : <http://example/> \
+                         PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\
+                         INSERT DATA {\
+                           :dt1 :r "2006-08-23" .\
+}';
+            engine.execute(query, function(success, result){
+                engine.execute('PREFIX :     <http://example/>\
+                                PREFIX xsd:  <http://www.w3.org/2001/XMLSchema#>\
+                                SELECT ?x ?date { \
+                                  ?x :r ?date .\
+                                  FILTER ( xsd:dateTime(?date) > "2006-01-01"^^xsd:dateTime  )\
+                                }', function(success, results){
+                                    test.ok(success === true);
+                                    test.ok(results.length===1);
+                                    test.done();
+                });
+            });
+        });
+    });
+}
+
 exports.testOpenCmp01 = function(test) {
     new Lexicon.Lexicon(function(lexicon){
         new QuadBackend.QuadBackend({treeOrder: 2}, function(backend){

--- a/src/js-trees/src/utils.js
+++ b/src/js-trees/src/utils.js
@@ -152,58 +152,8 @@ Utils.iso8601 = function(date) {
 };
 
 
-Utils.parseStrictISO8601 = function (str) {
-    var regexp = "([0-9]{4})(-([0-9]{2})(-([0-9]{2})" +
-        "(T([0-9]{2}):([0-9]{2})(:([0-9]{2})(\.([0-9]+))?)?" +
-        "(Z|(([-+])([0-9]{2}):([0-9]{2})))?)?)?)?";
-    var d = str.match(new RegExp(regexp));
-
-    var offset = 0;
-    var date = new Date(d[1], 0, 1);
-
-    if (d[3]) {
-        date.setMonth(d[3] - 1);
-    } else {
-        throw "missing ISO8061 component"
-    }
-    if (d[5]) {
-        date.setDate(d[5]);
-    } else {
-        throw "missing ISO8061 component"
-    }
-    if (d[7]) {
-        date.setHours(d[7]);
-    } else {
-        throw "missing ISO8061 component"
-    }
-    if (d[8]) {
-        date.setMinutes(d[8]);
-    } else {
-        throw "missing ISO8061 component"
-    }
-    if (d[10]) {
-        date.setSeconds(d[10]);
-    } else {
-        throw "missing ISO8061 component"
-    }
-    if (d[12]) {
-        date.setMilliseconds(Number("0." + d[12]) * 1000);
-    }
-    if (d[14]) {
-        offset = (Number(d[16]) * 60) + Number(d[17]);
-        offset *= ((d[15] == '-') ? 1 : -1);
-    }
-
-    offset -= date.getTimezoneOffset();
-    var time = (Number(date) + (offset * 60 * 1000));
-    var toReturn = new Date();
-    toReturn.setTime(Number(time));
-    return toReturn;
-};
-
-
 Utils.parseISO8601 = function (str) {
-    var regexp = "([0-9]{4})(-([0-9]{2})(-([0-9]{2})" +
+    var regexp = "^([0-9]{4})(-([0-9]{2})(-([0-9]{2})" +
         "(T([0-9]{2}):([0-9]{2})(:([0-9]{2})(\.([0-9]+))?)?" +
         "(Z|(([-+])([0-9]{2}):([0-9]{2})))?)?)?)?";
     var d = str.match(new RegExp(regexp));


### PR DESCRIPTION
Fixes antoniogarrote/rdfstore-js#37

1.  Don't require strict ISO8601 parsing for literal dates (e.g. "2000-01-05" should be allowed in > comparisons, even though it doesn't have precision down to the second)

2.  Require tolerant ISO860 parsing to match from the *beginning* of a string

3.  Added a test case