### PR TITLE
Use JSON.parse instead of eval to comply with CSP.

### DIFF
--- a/src/js-trees/src/utils.js
+++ b/src/js-trees/src/utils.js
@@ -412,7 +412,7 @@ Utils.normalizeUnicodeLiterals = function (string) {
     for (var i = 0; i < escapedUnicode.length; i++) {
         if (dups[escapedUnicode[i]] == null) {
             dups[escapedUnicode[i]] = true;
-            string = string.replace(new RegExp("\\" + escapedUnicode[i], "g"), eval("'" + escapedUnicode[i] + "'"));
+            string = string.replace(new RegExp("\\" + escapedUnicode[i], "g"), JSON.parse('"' + escapedUnicode[i] + '"'));
         }
     }
 


### PR DESCRIPTION
[Content Security Policy (CSP)](http://www.w3.org/TR/CSP/) has an option to disallow the use of `eval`. Chrome apps enforce this option by default. In `normalizeUnicodeLiterals`, `eval` can be safely replaced by `JSON.parse`.