### PR TITLE
N3 parser incorrectly expected punctuation after datatype

### DIFF
--- a/src/js-communication/src/rvn3_parser.js
+++ b/src/js-communication/src/rvn3_parser.js
@@ -549,7 +549,7 @@ RVInnerN3Parser.prototype = {
         this._object += '^^<' + value + '>';
         this._object = {literal: this._object};
       }
-      return this._readPunctuation;
+      return this._getNextReader();
     case 'langcode':
         if(this._object.literal) {
             this._object.literal += '@' + token.value.toLowerCase();


### PR DESCRIPTION
The N3 parser incorrectly expected punctuation after a datatype (but not after a langcode). This meant that N3/Turtle like the following didn't parse:

    _:a foo:bar [ skos:notation "123"^^foo:baz ]