### PR TITLE
More robust quote escaping

### DIFF
--- a/src/js-query-engine/src/rdf_js_interface.js
+++ b/src/js-query-engine/src/rdf_js_interface.js
@@ -376,26 +376,32 @@ RDFJSInterface.Literal = function(value, language, datatype) {
 Utils.extends(RDFJSInterface.RDFNode,RDFJSInterface.Literal);
 
 RDFJSInterface.Literal.prototype.toString = function(){
-    if(this.nominalValue.match(/"/)) {
-        var tmp = "'"+this.nominalValue+"'";
-        if(this.nominalValue.match(/'/)) {
-            var tmp = '"""'+this.nominalValue+'"""';
-            if(this.nominalValue.match(/"""/)) {
-                var tmp = "'''"+this.nominalValue+"'''";
-                if(this.nominalValue.match(/'''/)) {
-                    throw "Literal not possible to escape in a String.";
-                }
-            }
+    if(this.nominalValue.match("\n")) {
+        var tmp = '"""'+this.nominalValue+'"""';
+        if(this.nominalValue.match(/"""/)) {
+            var tmp = "'''"+this.nominalValue+"'''";
         }
     } else {
-        var tmp = '"'+this.nominalValue+'"';
+        if(this.nominalValue.match(/"/)) {
+            var tmp = "'"+this.nominalValue+"'";
+            if(this.nominalValue.match(/'/)) {
+                var tmp = '"""'+this.nominalValue+'"""';
+                if(this.nominalValue.match(/"""/)) {
+                    var tmp = "'''"+this.nominalValue+"'''";
+                    if(this.nominalValue.match(/'''/)) {
+                        throw "Literal not possible to escape in a String.";
+                    }
+                }
+            }
+        } else {
+            var tmp = '"'+this.nominalValue+'"';
+        }
     };
     if(this.language != null) {
         tmp = tmp + "@" + this.language;
     } else if(this.datatype != null || this.type) {
         tmp = tmp + "^^<" + (this.datatype||this.type) + ">";
     }
-
     return tmp;
 };
 

--- a/src/js-query-engine/src/rdf_js_interface.js
+++ b/src/js-query-engine/src/rdf_js_interface.js
@@ -376,7 +376,20 @@ RDFJSInterface.Literal = function(value, language, datatype) {
 Utils.extends(RDFJSInterface.RDFNode,RDFJSInterface.Literal);
 
 RDFJSInterface.Literal.prototype.toString = function(){
-    var tmp = '"'+this.nominalValue+'"';
+    if(this.nominalValue.match(/"/)) {
+        var tmp = "'"+this.nominalValue+"'";
+        if(this.nominalValue.match(/'/)) {
+            var tmp = '"""'+this.nominalValue+'"""';
+            if(this.nominalValue.match(/"""/)) {
+                var tmp = "'''"+this.nominalValue+"'''";
+                if(this.nominalValue.match(/'''/)) {
+                    throw "Literal not possible to escape in a String.";
+                }
+            }
+        }
+    } else {
+        var tmp = '"'+this.nominalValue+'"';
+    };
     if(this.language != null) {
         tmp = tmp + "@" + this.language;
     } else if(this.datatype != null || this.type) {

--- a/src/js-sparql-parser/lib/pegjs/examples/sparql_query_case.pegjs
+++ b/src/js-sparql-parser/lib/pegjs/examples/sparql_query_case.pegjs
@@ -2520,18 +2520,16 @@ STRING_LITERAL2 "[140] STRING_LITERAL2"
   =  '"' content:([^\u0022\u005C\u000A\u000D] / ECHAR)* '"' { return flattenString(content) }
 
 /*
-  @todo check
   [141]  	STRING_LITERAL_LONG1	  ::=  	"'''" ( ( "'" | "''" )? ( [^'\] | ECHAR ) )* "'''"
 */
 STRING_LITERAL_LONG1 "[141] STRING_LITERAL_LONG1"
-  = "'''" content:([^\'\\] / ECHAR)* "'''"  { return flattenString(content) }
+  = "'''" content:(("'"/"''")?[^\'] / ECHAR)* "'''"  { return flattenString(content) }
 
 /*
-  @todo check
   [142]  	STRING_LITERAL_LONG2	  ::=  	'"""' ( ( '"' | '""' )? ( [^"\] | ECHAR ) )* '"""'
 */
 STRING_LITERAL_LONG2 "[142] STRING_LITERAL_LONG2"
-  = '"""' content:([^\"\\] / ECHAR)* '"""'  { return flattenString(content) }
+  = '"""' content:(("\""/"\"\"")?[^\"] / ECHAR)* '"""'  { return flattenString(content) }
 
 /*
   [143]  	ECHAR	  ::=  	'\' [tbnrf\"']

--- a/src/js-sparql-parser/src/sparql_parser.js
+++ b/src/js-sparql-parser/src/sparql_parser.js
@@ -16389,8 +16389,8 @@ SparqlParser.parser = (function(){
       }
       
       function parse_STRING_LITERAL_LONG1() {
-        var result0, result1, result2;
-        var pos0, pos1;
+        var result0, result1, result2, result3;
+        var pos0, pos1, pos2;
         
         reportFailures++;
         pos0 = pos;
@@ -16406,28 +16406,94 @@ SparqlParser.parser = (function(){
         }
         if (result0 !== null) {
           result1 = [];
-          if (/^[^'\\]/.test(input.charAt(pos))) {
-            result2 = input.charAt(pos);
+          pos2 = pos;
+          if (input.charCodeAt(pos) === 39) {
+            result2 = "'";
             pos++;
           } else {
             result2 = null;
             if (reportFailures === 0) {
-              matchFailed("[^'\\\\]");
+              matchFailed("\"'\"");
             }
+          }
+          if (result2 === null) {
+            if (input.substr(pos, 2) === "''") {
+              result2 = "''";
+              pos += 2;
+            } else {
+              result2 = null;
+              if (reportFailures === 0) {
+                matchFailed("\"''\"");
+              }
+            }
+          }
+          result2 = result2 !== null ? result2 : "";
+          if (result2 !== null) {
+            if (/^[^']/.test(input.charAt(pos))) {
+              result3 = input.charAt(pos);
+              pos++;
+            } else {
+              result3 = null;
+              if (reportFailures === 0) {
+                matchFailed("[^']");
+              }
+            }
+            if (result3 !== null) {
+              result2 = [result2, result3];
+            } else {
+              result2 = null;
+              pos = pos2;
+            }
+          } else {
+            result2 = null;
+            pos = pos2;
           }
           if (result2 === null) {
             result2 = parse_ECHAR();
           }
           while (result2 !== null) {
             result1.push(result2);
-            if (/^[^'\\]/.test(input.charAt(pos))) {
-              result2 = input.charAt(pos);
+            pos2 = pos;
+            if (input.charCodeAt(pos) === 39) {
+              result2 = "'";
               pos++;
             } else {
               result2 = null;
               if (reportFailures === 0) {
-                matchFailed("[^'\\\\]");
+                matchFailed("\"'\"");
               }
+            }
+            if (result2 === null) {
+              if (input.substr(pos, 2) === "''") {
+                result2 = "''";
+                pos += 2;
+              } else {
+                result2 = null;
+                if (reportFailures === 0) {
+                  matchFailed("\"''\"");
+                }
+              }
+            }
+            result2 = result2 !== null ? result2 : "";
+            if (result2 !== null) {
+              if (/^[^']/.test(input.charAt(pos))) {
+                result3 = input.charAt(pos);
+                pos++;
+              } else {
+                result3 = null;
+                if (reportFailures === 0) {
+                  matchFailed("[^']");
+                }
+              }
+              if (result3 !== null) {
+                result2 = [result2, result3];
+              } else {
+                result2 = null;
+                pos = pos2;
+              }
+            } else {
+              result2 = null;
+              pos = pos2;
             }
             if (result2 === null) {
               result2 = parse_ECHAR();
@@ -16471,8 +16537,8 @@ SparqlParser.parser = (function(){
       }
       
       function parse_STRING_LITERAL_LONG2() {
-        var result0, result1, result2;
-        var pos0, pos1;
+        var result0, result1, result2, result3;
+        var pos0, pos1, pos2;
         
         reportFailures++;
         pos0 = pos;
@@ -16488,28 +16554,94 @@ SparqlParser.parser = (function(){
         }
         if (result0 !== null) {
           result1 = [];
-          if (/^[^"\\]/.test(input.charAt(pos))) {
-            result2 = input.charAt(pos);
+          pos2 = pos;
+          if (input.charCodeAt(pos) === 34) {
+            result2 = "\"";
             pos++;
           } else {
             result2 = null;
             if (reportFailures === 0) {
-              matchFailed("[^\"\\\\]");
+              matchFailed("\"\\\"\"");
             }
+          }
+          if (result2 === null) {
+            if (input.substr(pos, 2) === "\"\"") {
+              result2 = "\"\"";
+              pos += 2;
+            } else {
+              result2 = null;
+              if (reportFailures === 0) {
+                matchFailed("\"\\\"\\\"\"");
+              }
+            }
+          }
+          result2 = result2 !== null ? result2 : "";
+          if (result2 !== null) {
+            if (/^[^"]/.test(input.charAt(pos))) {
+              result3 = input.charAt(pos);
+              pos++;
+            } else {
+              result3 = null;
+              if (reportFailures === 0) {
+                matchFailed("[^\"]");
+              }
+            }
+            if (result3 !== null) {
+              result2 = [result2, result3];
+            } else {
+              result2 = null;
+              pos = pos2;
+            }
+          } else {
+            result2 = null;
+            pos = pos2;
           }
           if (result2 === null) {
             result2 = parse_ECHAR();
           }
           while (result2 !== null) {
             result1.push(result2);
-            if (/^[^"\\]/.test(input.charAt(pos))) {
-              result2 = input.charAt(pos);
+            pos2 = pos;
+            if (input.charCodeAt(pos) === 34) {
+              result2 = "\"";
               pos++;
             } else {
               result2 = null;
               if (reportFailures === 0) {
-                matchFailed("[^\"\\\\]");
+                matchFailed("\"\\\"\"");
               }
+            }
+            if (result2 === null) {
+              if (input.substr(pos, 2) === "\"\"") {
+                result2 = "\"\"";
+                pos += 2;
+              } else {
+                result2 = null;
+                if (reportFailures === 0) {
+                  matchFailed("\"\\\"\\\"\"");
+                }
+              }
+            }
+            result2 = result2 !== null ? result2 : "";
+            if (result2 !== null) {
+              if (/^[^"]/.test(input.charAt(pos))) {
+                result3 = input.charAt(pos);
+                pos++;
+              } else {
+                result3 = null;
+                if (reportFailures === 0) {
+                  matchFailed("[^\"]");
+                }
+              }
+              if (result3 !== null) {
+                result2 = [result2, result3];
+              } else {
+                result2 = null;
+                pos = pos2;
+              }
+            } else {
+              result2 = null;
+              pos = pos2;
             }
             if (result2 === null) {
               result2 = parse_ECHAR();

--- a/src/js-store/src/store.js
+++ b/src/js-store/src/store.js
@@ -644,14 +644,7 @@ Store.Store.prototype._nodeToQuery = function(term) {
         } else {
             return "<" + term.valueOf() + ">";
         }
-    } else if(term.interfaceName === '') {
-        return term.toString();
     } else {
-        if(term.lang != null) {
-            return "\""+term.valueOf()+"\"@"+term.lang;
-        } else if(term.datatype != null) {
-            return "\""+term.valueOf()+"\"^^<"+term.datatype+">";
-        }
         return term.toString();
     }
 };
@@ -921,22 +914,6 @@ Store.Store.prototype.registeredGraphs = function(callback) {
         }
      
         return callback(true, acum);    
-    }
-};
-
-/** @private */
-Store.Store.prototype._nodeToQuery = function(term) {
-    if(term.interfaceName === 'NamedNode') {
-        var resolvedUri = this.rdf.resolve(term.valueOf());
-        if(resolvedUri != null) {
-            return "<" + resolvedUri + ">";
-        } else {
-            return "<" + term.valueOf() + ">";
-        }
-    } else if(term.interfaceName === '') {
-        return term.toString();
-    } else {
-        return term.toString();
     }
 };
 

--- a/src/js-store/src/store.js
+++ b/src/js-store/src/store.js
@@ -609,8 +609,8 @@ Store.Store.prototype.insert = function() {
     var callback;
     if(arguments.length === 1) {
         triples = arguments[0];
+        callback= function(){};
     } else if(arguments.length === 2) {
-        graph = this.rdf.createNamedNode(this.engine.lexicon.defaultGraphUri);
         triples = arguments[0];
         callback= arguments[1] || function(){};
     } else if(arguments.length === 3) {
@@ -630,7 +630,7 @@ Store.Store.prototype.insert = function() {
     if(graph != null) {
         query = "INSERT DATA { GRAPH " + this._nodeToQuery(graph) +" { "+ query + " } }";
     } else {
-        query = "INSERT DATA { " + this._nodeToQuery(graph) +" { "+ query + " }";
+        query = "INSERT DATA { "+ query + " }";
     }
 
     this.engine.execute(query, callback);
@@ -680,8 +680,8 @@ Store.Store.prototype.delete = function() {
     var callback;
     if(arguments.length === 1) {
         triples = arguments[0];
+        callback= function(){};
     } else if(arguments.length === 2) {
-        graph = this.rdf.createNamedNode(this.engine.lexicon.defaultGraphUri);
         triples = arguments[0];
         callback= arguments[1] || function(){};
     } else if(arguments.length === 3) {
@@ -701,7 +701,7 @@ Store.Store.prototype.delete = function() {
     if(graph != null) {
         query = "DELETE DATA { GRAPH " + this._nodeToQuery(graph) +" { "+ query + " } }";
     } else {
-        query = "DELETE DATA { " + this._nodeToQuery(graph) +" { "+ query + " }";
+        query = "DELETE DATA { "+ query + " }";
     }
 
     this.engine.execute(query, callback);


### PR DESCRIPTION
This changes are quite deep in rdfstore-js. I had some problems with doublequotes in literal strings not going through directly.

First there is a change in RDFInterface which does create escaped Literals as of http://www.w3.org/TR/2012/WD-turtle-20120710/#turtle-literals if calling `.toString()` / `.toNT()`

Which makes it possible to simplify the .`_nodeToQuery()` which passes the change through.

And last we did change the sparql_parser.js to accept triple double quote (""") and triple single quote (''') strings with double or respectively single quotes in them. (Here I got the problem that sparql_query_case.pegs is not in sync with the actual sparql_parser.js ... but no regression found so far. Tests are all working.)