### PR TITLE
JSON-LD update: replaced @context by @value

### DIFF
--- a/src/js-communication/src/jsonld_parser.js
+++ b/src/js-communication/src/jsonld_parser.js
@@ -214,7 +214,7 @@ var _getKeywords = function(ctx)
    {
       '@id': '@id',
       '@language': '@language',
-      '@literal': '@literal',
+      '@value': '@value',
       '@type': '@type'
    };
    
@@ -461,7 +461,7 @@ var _isSubject = function(value)
    // 1. It is an Object.
    // 2. It is not a literal.
    // 3. It has more than 1 key OR any existing key is not '@id'.
-   if(value !== null && value.constructor === Object && !('@literal' in value))
+   if(value !== null && value.constructor === Object && !('@value' in value))
    {
       var keyCount = Object.keys(value).length;
       rval = (keyCount > 1 || !('@id' in value));
@@ -753,9 +753,9 @@ jsonld.toTriples = function(input, graph, callback)
                         obji2 = {'token':'uri', 'value':obji2['@id']};
                     }
                 } else if(obji2['@type'] != null) {
-                    obji2 = {'token':'literal', 'value':obji2['@literal'], 'type':obji2['@type']};
+                    obji2 = {'token':'literal', 'value':obji2['@value'], 'type':obji2['@type']};
                 } else if(obji2['@language'] != null) {
-                    obji2 = {'token':'literal', 'value':obji2['@literal'], 'lang':obji2['@language']};
+                    obji2 = {'token':'literal', 'value':obji2['@value'], 'lang':obji2['@language']};
                 }
 
 		quit = (callback(s, {'token':'uri', 'value':p}, obji2) === false);
@@ -1052,9 +1052,9 @@ Processor.prototype.compact = function(ctx, property, value, usedCtx)
                {
                   rval = value['@id'];
                }
-               else if('@literal' in value)
+               else if('@value' in value)
                {
-                  rval = value['@literal'];
+                  rval = value['@value'];
                }
             }
             else
@@ -1223,7 +1223,7 @@ Processor.prototype.expand = function(ctx, property, value)
                value = value.toExponential(6).replace(
                   /(e(?:\+|-))([0-9])$/, '$10$2');
             }
-            rval['@literal'] = '' + value;
+            rval['@value'] = '' + value;
          }
       }
       // nothing to coerce
@@ -1441,10 +1441,10 @@ var _compareObjects = function(o1, o2)
    }
    else
    {
-      rval = _compareObjectKeys(o1, o2, '@literal');
+      rval = _compareObjectKeys(o1, o2, '@value');
       if(rval === 0)
       {
-         if('@literal' in o1)
+         if('@value' in o1)
          {
             rval = _compareObjectKeys(o1, o2, '@type');
             if(rval === 0)
@@ -1482,8 +1482,8 @@ var _compareBlankNodeObjects = function(a, b)
    3.2.1. The bnode with fewer non-bnodes is first.
    3.2.2. The bnode with a string object is first.
    3.2.3. The bnode with the alphabetically-first string is first.
-   3.2.4. The bnode with a @literal is first.
-   3.2.5. The bnode with the alphabetically-first @literal is first.
+   3.2.4. The bnode with a @value is first.
+   3.2.5. The bnode with the alphabetically-first @value is first.
    3.2.6. The bnode with the alphabetically-first @type is first.
    3.2.7. The bnode with a @language is first.
    3.2.8. The bnode with the alphabetically-first @language is first.
@@ -1647,7 +1647,7 @@ var _flatten = function(parent, parentProperty, value, subjects)
    else if(value.constructor === Object)
    {
       // already-expanded value or special-case reference-only @type
-      if('@literal' in value || parentProperty === '@type')
+      if('@value' in value || parentProperty === '@type')
       {
          flattened = _clone(value);
       }
@@ -2122,7 +2122,7 @@ var _serializeProperties = function(b)
                // literal
                else
                {
-                  rval += '"' + o['@literal'] + '"';
+                  rval += '"' + o['@value'] + '"';
                   
                   // type literal
                   if('@type' in o)

--- a/src/js-communication/test/jsonld_parser.js
+++ b/src/js-communication/test/jsonld_parser.js
@@ -216,7 +216,7 @@ exports.testParsing6 = function(test) {
     test.ok(result[0].object.uri === "http://manu.sporny.org");
  
  
-    input = {"foaf:name": { "@literal": "花澄", "@language": "ja"  } };
+    input = {"foaf:name": { "@value": "花澄", "@language": "ja"  } };
  
     result = JSONLDParser.parser.parse(input);
     


### PR DESCRIPTION
Somewhere between [this draft](http://json-ld.org/spec/ED/json-ld-syntax/20110615/) and the [final recommendation](http://www.w3.org/TR/json-ld/), `"@literal"` was replaced by `"@value"`. That's reflected in the changes of the Pull request. 

I was able to run the jsonld-related tests successfully (had to adapt one test case), but I didn't manage to get the complete test suite (`./make.rb tests`) to run. 