### PR TITLE
Fixed normalizeQuad call for observeQuery

### DIFF
--- a/dist/rdfstore.js
+++ b/dist/rdfstore.js
@@ -1238,7 +1238,7 @@ var lookup = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
 }(typeof exports === 'undefined' ? (this.base64js = {}) : exports))
 
 },{}],4:[function(_dereq_,module,exports){
-exports.read = function(buffer, offset, isLE, mLen, nBytes) {
+exports.read = function (buffer, offset, isLE, mLen, nBytes) {
   var e, m,
       eLen = nBytes * 8 - mLen - 1,
       eMax = (1 << eLen) - 1,
@@ -1246,32 +1246,32 @@ exports.read = function(buffer, offset, isLE, mLen, nBytes) {
       nBits = -7,
       i = isLE ? (nBytes - 1) : 0,
       d = isLE ? -1 : 1,
-      s = buffer[offset + i];
+      s = buffer[offset + i]
 
-  i += d;
+  i += d
 
-  e = s & ((1 << (-nBits)) - 1);
-  s >>= (-nBits);
-  nBits += eLen;
-  for (; nBits > 0; e = e * 256 + buffer[offset + i], i += d, nBits -= 8);
+  e = s & ((1 << (-nBits)) - 1)
+  s >>= (-nBits)
+  nBits += eLen
+  for (; nBits > 0; e = e * 256 + buffer[offset + i], i += d, nBits -= 8) {}
 
-  m = e & ((1 << (-nBits)) - 1);
-  e >>= (-nBits);
-  nBits += mLen;
-  for (; nBits > 0; m = m * 256 + buffer[offset + i], i += d, nBits -= 8);
+  m = e & ((1 << (-nBits)) - 1)
+  e >>= (-nBits)
+  nBits += mLen
+  for (; nBits > 0; m = m * 256 + buffer[offset + i], i += d, nBits -= 8) {}
 
   if (e === 0) {
-    e = 1 - eBias;
+    e = 1 - eBias
   } else if (e === eMax) {
-    return m ? NaN : ((s ? -1 : 1) * Infinity);
+    return m ? NaN : ((s ? -1 : 1) * Infinity)
   } else {
-    m = m + Math.pow(2, mLen);
-    e = e - eBias;
+    m = m + Math.pow(2, mLen)
+    e = e - eBias
   }
-  return (s ? -1 : 1) * m * Math.pow(2, e - mLen);
-};
+  return (s ? -1 : 1) * m * Math.pow(2, e - mLen)
+}
 
-exports.write = function(buffer, value, offset, isLE, mLen, nBytes) {
+exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
   var e, m, c,
       eLen = nBytes * 8 - mLen - 1,
       eMax = (1 << eLen) - 1,
@@ -1279,49 +1279,49 @@ exports.write = function(buffer, value, offset, isLE, mLen, nBytes) {
       rt = (mLen === 23 ? Math.pow(2, -24) - Math.pow(2, -77) : 0),
       i = isLE ? 0 : (nBytes - 1),
       d = isLE ? 1 : -1,
-      s = value < 0 || (value === 0 && 1 / value < 0) ? 1 : 0;
+      s = value < 0 || (value === 0 && 1 / value < 0) ? 1 : 0
 
-  value = Math.abs(value);
+  value = Math.abs(value)
 
   if (isNaN(value) || value === Infinity) {
-    m = isNaN(value) ? 1 : 0;
-    e = eMax;
+    m = isNaN(value) ? 1 : 0
+    e = eMax
   } else {
-    e = Math.floor(Math.log(value) / Math.LN2);
+    e = Math.floor(Math.log(value) / Math.LN2)
     if (value * (c = Math.pow(2, -e)) < 1) {
-      e--;
-      c *= 2;
+      e--
+      c *= 2
     }
     if (e + eBias >= 1) {
-      value += rt / c;
+      value += rt / c
     } else {
-      value += rt * Math.pow(2, 1 - eBias);
+      value += rt * Math.pow(2, 1 - eBias)
     }
     if (value * c >= 2) {
-      e++;
-      c /= 2;
+      e++
+      c /= 2
     }
 
     if (e + eBias >= eMax) {
-      m = 0;
-      e = eMax;
+      m = 0
+      e = eMax
     } else if (e + eBias >= 1) {
-      m = (value * c - 1) * Math.pow(2, mLen);
-      e = e + eBias;
+      m = (value * c - 1) * Math.pow(2, mLen)
+      e = e + eBias
     } else {
-      m = value * Math.pow(2, eBias - 1) * Math.pow(2, mLen);
-      e = 0;
+      m = value * Math.pow(2, eBias - 1) * Math.pow(2, mLen)
+      e = 0
     }
   }
 
-  for (; mLen >= 8; buffer[offset + i] = m & 0xff, i += d, m /= 256, mLen -= 8);
+  for (; mLen >= 8; buffer[offset + i] = m & 0xff, i += d, m /= 256, mLen -= 8) {}
 
-  e = (e << mLen) | m;
-  eLen += mLen;
-  for (; eLen > 0; buffer[offset + i] = e & 0xff, i += d, e /= 256, eLen -= 8);
+  e = (e << mLen) | m
+  eLen += mLen
+  for (; eLen > 0; buffer[offset + i] = e & 0xff, i += d, e /= 256, eLen -= 8) {}
 
-  buffer[offset + i - d] |= s * 128;
-};
+  buffer[offset + i - d] |= s * 128
+}
 
 },{}],5:[function(_dereq_,module,exports){
 // Copyright Joyent, Inc. and other Node contributors.
@@ -15357,6 +15357,8 @@ function N3Parser(options) {
       return this._callback = noop, this._subject = null;
     };
   }
+  this._blankNodePrefix = typeof options.blankNodePrefix !== 'string' ? '' :
+                            '_:' + options.blankNodePrefix.replace(/^_:/, '');
   this._lexer = options.lexer || new N3Lexer({ lineMode: isLineMode });
 }
 
@@ -15905,7 +15907,7 @@ N3Parser.prototype = {
     // We start reading in the top context.
     this._readCallback = this._readInTopContext;
     this._prefixes = Object.create(null);
-    this._prefixes._ = '_:b' + blankNodePrefix++ + '_';
+    this._prefixes._ = this._blankNodePrefix || '_:b' + blankNodePrefix++ + '_';
 
     // If the input argument is not given, shift parameters
     if (typeof input === 'function')
@@ -18902,32 +18904,32 @@ Callbacks.CallbacksBackend.prototype.observeQuery = function(query, callback, en
             quad.graph = that.engine.lexicon.defaultGraphUriTerm;
         }
 
-        var normalized = that.engine.normalizeQuad(quad, queryEnv, true);
-        pattern =  new Pattern(normalized);
-        indexKey = that._indexForPattern(pattern);
-        indexOrder = that.componentOrders[indexKey];
-        index = that.queriesIndexMap[indexKey];
+        that.engine.normalizeQuad(quad, queryEnv, true, function(normalized) {
+          var pattern =  new Pattern(normalized);
+          var indexKey = that._indexForPattern(pattern);
+          var indexOrder = that.componentOrders[indexKey];
+          var index = that.queriesIndexMap[indexKey];
 
-        for(var j=0; j<indexOrder.length; j++) {
+          for(var j=0; j<indexOrder.length; j++) {
             var component = indexOrder[j];
             var quadValue = normalized[component];
             if(typeof(quadValue) === 'string') {
-                if(index['_'] == null) {
-                    index['_'] = [];
-                }
-                index['_'].push(counter);
-                break;
+              if(index['_'] == null) {
+                index['_'] = [];
+              }
+              index['_'].push(counter);
+              break;
             } else {
-                if(j===indexOrder.length-1) {
-                    index[quadValue] = index[quadValue] || {'_':[]};
-                    index[quadValue]['_'].push(counter);
-                } else {
-                    index[quadValue] = index[quadValue] || {};
-                    index = index[quadValue];
-                }
+              if(j===indexOrder.length-1) {
+                index[quadValue] = index[quadValue] || {'_':[]};
+                index[quadValue]['_'].push(counter);
+              } else {
+                index[quadValue] = index[quadValue] || {};
+                index = index[quadValue];
+              }
             }
-        }
-
+          }
+        });
     }
 
     this.engine.execute(query, function(err, results){

--- a/src/graph_callbacks.js
+++ b/src/graph_callbacks.js
@@ -376,7 +376,6 @@ Callbacks.CallbacksBackend.prototype.observeQuery = function(query, callback, en
     var that = this;
     var queryEnv = {blanks:{}, outCache:{}};
     this.engine.registerNsInEnvironment(null, queryEnv);
-    var pattern, quad, indexKey, indexOrder, index;
 
     var counter = this.queryCounter;
     this.queryCounter++;
@@ -386,7 +385,7 @@ Callbacks.CallbacksBackend.prototype.observeQuery = function(query, callback, en
     this.queriesCallbacksMap[counter] = callback;
 
     for(var i=0; i<patterns.length; i++) {
-        quad = patterns[i];
+        var quad = patterns[i];
         if(quad.graph == null) {
             quad.graph = that.engine.lexicon.defaultGraphUriTerm;
         }

--- a/src/graph_callbacks.js
+++ b/src/graph_callbacks.js
@@ -391,32 +391,32 @@ Callbacks.CallbacksBackend.prototype.observeQuery = function(query, callback, en
             quad.graph = that.engine.lexicon.defaultGraphUriTerm;
         }
 
-        var normalized = that.engine.normalizeQuad(quad, queryEnv, true);
-        pattern =  new Pattern(normalized);
-        indexKey = that._indexForPattern(pattern);
-        indexOrder = that.componentOrders[indexKey];
-        index = that.queriesIndexMap[indexKey];
+        that.engine.normalizeQuad(quad, queryEnv, true, function(normalized) {
+          var pattern =  new Pattern(normalized);
+          var indexKey = that._indexForPattern(pattern);
+          var indexOrder = that.componentOrders[indexKey];
+          var index = that.queriesIndexMap[indexKey];
 
-        for(var j=0; j<indexOrder.length; j++) {
+          for(var j=0; j<indexOrder.length; j++) {
             var component = indexOrder[j];
             var quadValue = normalized[component];
             if(typeof(quadValue) === 'string') {
-                if(index['_'] == null) {
-                    index['_'] = [];
-                }
-                index['_'].push(counter);
-                break;
+              if(index['_'] == null) {
+                index['_'] = [];
+              }
+              index['_'].push(counter);
+              break;
             } else {
-                if(j===indexOrder.length-1) {
-                    index[quadValue] = index[quadValue] || {'_':[]};
-                    index[quadValue]['_'].push(counter);
-                } else {
-                    index[quadValue] = index[quadValue] || {};
-                    index = index[quadValue];
-                }
+              if(j===indexOrder.length-1) {
+                index[quadValue] = index[quadValue] || {'_':[]};
+                index[quadValue]['_'].push(counter);
+              } else {
+                index[quadValue] = index[quadValue] || {};
+                index = index[quadValue];
+              }
             }
-        }
-
+          }
+        });
     }
 
     this.engine.execute(query, function(err, results){


### PR DESCRIPTION
I experienced a crash in the browser version of rdfstore-js while using startObservingNode.

QueryEngine.prototype.normalizeQuad doesn't return anything but uses a callback.
I fixed the call in Callbacks.CallbacksBackend.prototype.observeQuery by providing a proper callback function.