### PR TITLE
Fixing batchLoad if condition #98

### DIFF
--- a/src/query_engine.js
+++ b/src/query_engine.js
@@ -1466,7 +1466,7 @@ QueryEngine.prototype.batchLoad = function(quads, callback) {
             that.backend.search(key, function(result){
                 if(!result) {
                     that.backend.index(key, function(result){
-                        if(result == true){
+                        if(result){
                             if(that.eventsOnBatchLoad)
                                 that.callbacksBackend.nextGraphModification(Callbacks.added, [originalQuad,quad]);
                             counter = counter + 1;


### PR DESCRIPTION
This `if` condition compares an object to == true, while the objective here is to check if the result is an object (so true, but not ==true).

This if condition skips the `callbacksBackend.nextGraphModification`, and more importantly the `counter` to update