### PR TITLE
Expose RDFLoader class to global context + Pass file format information from Loader to Parser + fix typo

### DIFF
--- a/src/query_engine.js
+++ b/src/query_engine.js
@@ -6,7 +6,7 @@ var QuadIndex = require("./quad_index");
 var QueryPlan = require("./query_plan").QueryPlan;
 var QueryFilters = require("./query_filters").QueryFilters;
 var RDFModel = require("./rdf_model");
-var RDFLoader = require("./rdf_loader").RDFLoader;
+var RDFLoader = require("./rdf_loader");
 var Callbacks = require("./graph_callbacks").CallbacksBackend;
 var async = require('./utils');
 var _ = require('./utils');
@@ -1382,7 +1382,7 @@ QueryEngine.prototype.executeUpdate = function(syntaxTree, callback) {
                 } else {
                     that.batchLoad(result,function(result){
                         if(result !== null) {
-                            callback(null, rsult);
+                            callback(null, result);
                         } else {
                             callback(new Error("Error batch loading quads"));
                         }

--- a/src/rdf_loader.js
+++ b/src/rdf_loader.js
@@ -3,7 +3,7 @@ var RVN3Parser = require("./rvn3_parser").RVN3Parser;
 var JSONLDParser = require("./jsonld_parser").JSONLDParser;
 var Utils = require("./utils");
 
- var RDFLoader = function (params) {
+RDFLoader = function (params) {
 
     this.precedences = ["text/turtle", "text/n3", "application/ld+json", "application/json"];
     this.parsers = {"text/turtle":RVN3Parser.parser, "text/n3":RVN3Parser.parser, "application/ld+json":JSONLDParser.parser, "application/json":JSONLDParser.parser};
@@ -75,18 +75,18 @@ RDFLoader.prototype.load = function(uri, graph, callback) {
                         var mimeParts = m.split("/");
                         if(mimeParts[1] === '*') {
                             if(mime.indexOf(mimeParts[0])!=-1) {
-                                return that.tryToParse(that.parsers[m], graph, data, {documentURI: uri}, callback);
+                                return that.tryToParse(that.parsers[m], graph, data, {documentURI: uri, format: mimeParts[0]}, callback);
                             }
                         } else {
                             if(mime.indexOf(m)!=-1) {
-                                return that.tryToParse(that.parsers[m], graph, data, {documentURI: uri}, callback);
+                                return that.tryToParse(that.parsers[m], graph, data, {documentURI: uri, format: m}, callback);
                             } else if(mime.indexOf(mimeParts[1])!=-1) {
-                                return that.tryToParse(that.parsers[m], graph, data, {documentURI: uri}, callback);
+                                return that.tryToParse(that.parsers[m], graph, data, {documentURI: uri, format: mimeParts[1]}, callback);
                             }
                         }
                     } else {
                         if(mime.indexOf(m)!=-1) {
-                            return that.tryToParse(that.parsers[m], graph, data, {documentURI: uri}, callback);
+                            return that.tryToParse(that.parsers[m], graph, data, {documentURI: uri, format: m}, callback);
                         }
                     }
                 }
@@ -133,9 +133,7 @@ RDFLoader.prototype.tryToParse = function(parser, graph, input, options, callbac
     }
 };
 
-module.exports = {
-    RDFLoader: RDFLoader
-};
+module.exports = RDFLoader;
 
 
 // var loader = require("./js-communication/src/rdf_loader").RDFLoader; loader = new loader.RDFLoader(); loader.load('http://dbpedialite.org/titles/Lisp_%28programming_language%29', function(success, results){console.log("hey"); console.log(success); console.log(results)})


### PR DESCRIPTION
This is a rollup of three changes I have made to rdfstore-js sources while working on my current project.

I needed to override a prototype function on the `RDFLoader` Class from within another JS library, to add additional functionality. In order to do that I needed to expose `RDFLoader` to the global context. Several other classes such as `RDFModel` and `QueryEngine` are exposed globally so I think `RDFLoader` should also be accessible.

The second change is to pass a `format` parameter in the options struct from the `RDFLoader` to the selected parser via the `tryToParse` method. The N3 parser needs this option passed in to determine whether the file is Turtle or N3 in order to set some internal parsing options.

The final change is a small but nasty typo I found, which affects the use of the `store.load` helper.