### PR TITLE
Fix call to resolve blank function

### DIFF
--- a/src/query_engine.js
+++ b/src/query_engine.js
@@ -370,7 +370,7 @@ QueryEngine.prototype.normalizeTerm = function(term, env, shouldIndex, callback)
             } else {
                 // should never get here...
                 // is resolveBlank useful?
-                this.lexicon.resolveBlank(function(oid) {
+                this.lexicon.resolveBlank(label, function(oid) {
                     env.blanks[label] = oid;
                     callback(oid);
                 });


### PR DESCRIPTION
I know the code says that that this function should never execute, but I feel that it should still work correctly if it does. This pull request fixes the call to resolveBlank, though Im not sure it is actually returning the correct blank node, more testing is needed.

If this code should never execute, then how does a user find information about an anonymous block?
For example, is I call
```
SELECT ?o
WHERE { my:object rdf:type ?o }
```
and get a result which is `{blank, _:45}` then how do I get information about that block without doing
```
SELECT ?p ?o
WHERE { _:45 ?p ?o }
```
according to the code comment, placing a blank node in a SPARQL query is never a valid case. 
