### PR TITLE
Fixed N3Parser dependency failure on Node 5.x.

### DIFF
--- a/src/query_engine.js
+++ b/src/query_engine.js
@@ -1382,7 +1382,7 @@ QueryEngine.prototype.executeUpdate = function(syntaxTree, callback) {
                 } else {
                     that.batchLoad(result,function(result){
                         if(result !== null) {
-                            callback(null, rsult);
+                            callback(null, result);
                         } else {
                             callback(new Error("Error batch loading quads"));
                         }

--- a/src/rvn3_parser.js
+++ b/src/rvn3_parser.js
@@ -1,5 +1,5 @@
-//var N3Parser = require('n3').Parser;
-var N3Parser = require('../node_modules/n3/lib/N3Parser');
+var N3Parser = require('n3').Parser;
+//var N3Parser = require('../node_modules/n3/lib/N3Parser');
 
 // Add a wrapper around the N3.js parser
 var RVN3Parser = {};


### PR DESCRIPTION
Fix for:

```
module.js:341
    throw err;
    ^

Error: Cannot find module '../node_modules/n3/lib/N3Parser'
    at Function.Module._resolveFilename (module.js:339:15)
    at Function.Module._load (module.js:290:25)
    at Module.require (module.js:367:17)
    at require (internal/module.js:16:19)
    at Object.<anonymous> (/home/ferdinand/dev/new/rdf-test/node_modules/rdfstore/src/rvn3_parser.js:2:16)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Module.require (module.js:367:17)
```