### PR TITLE
Tweak denormalizeBindingsList performance

### DIFF
--- a/src/query_engine.js
+++ b/src/query_engine.js
@@ -584,7 +584,7 @@ QueryEngine.prototype.denormalizeBindings = function(bindings, env, lazyCache, c
                     k();
                 };
                 if (lazyCache['#'+oid]) {
-                    process.nextTick(function() { cb(lazyCache['#'+oid]) });
+                    _.nextTick(function() { cb(lazyCache['#'+oid]) });
                 }
                 else {
                     that.lexicon.retrieve(oid, cb);


### PR DESCRIPTION
The query engine often redundantly fetches same objects from the lexicon in denormalizeBindings(List). Using a lazy cache for the already fetched items reduces the request time significantly; an exemplar query took only 1.5 seconds instead of 10 without the tweak.