### PR TITLE
fix whilst function, allowing long running queries

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -358,7 +358,9 @@ var whilst = function (test, iterator, callback) {
             if (err) {
                 return callback(err);
             }
-            whilst(test, iterator, callback);
+            setTimeout(() => {
+              whilst(test, iterator, callback)
+            }, 0)
         });
     }
     else {


### PR DESCRIPTION

As pointed out in my comment for https://github.com/antoniogarrote/rdfstore-js/issues/128
**This fix allows long running queries that could normally reach a maximum call stack number.**

See my response in the issue: 

The number of Maximum call stack is not the same in nodejs or in a browser (https://stackoverflow.com/a/7828803/6126329)

This also appears in nodejs when you are trying to run a query on huge number of data. `async.whilst(function(){
                         ^
RangeError: Maximum call stack size exceeded`

This can be fixed by fixing the whilst function in utils.js (see https://stackoverflow.com/a/20999077/6126329). 
This fix will let node or the browser free the stack when needed.

```js
var whilst = function (test, iterator, callback) {
    if (test()) {
        iterator(function (err) {
            if (err) {
                return callback(err);
            }
            setTimeout(() => {
              whilst(test, iterator, callback)
            }, 0)
        });
    }
    else {
        callback();
    }
};
```
This fixed my problem.